### PR TITLE
Add a separate graph for paid installments and pending installments

### DIFF
--- a/frontend/src/components/project/details/installment/ProjectInstallmentChart.vue
+++ b/frontend/src/components/project/details/installment/ProjectInstallmentChart.vue
@@ -1,53 +1,160 @@
 <template>
-    <v-dialog max-width="800px">
-      <v-card  class="rounded-lg">
-        <v-card-title class="d-flex justify-end">
-          <v-btn icon @click="emitClose">
-            <v-icon>mdi-close</v-icon>
-          </v-btn>
-        </v-card-title>
-        <v-card-text>
-          <stacked-bar-chart v-if="installments.length > 0" :installments="installments" />
-        </v-card-text>
-      </v-card>
-    </v-dialog>
-  </template>
-  
-  <script>
-  import StackedBarChart from '@/components/shared/charts/BarChart.vue';
-  
-  export default {
-    name: 'ChartModal',
+  <v-dialog max-width="1200px" persistent>
+    <v-card class="rounded-lg">
+      <v-card-title class="d-flex justify-space-between align-center pa-4">
+        <h2 class="text-h5 text-md-h4">Visualização de Parcelas por Área</h2>
+        <v-btn icon @click="emitClose" class="ml-2">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </v-card-title>
+      
+      <v-divider></v-divider>
+      
+      <v-card-text class="pa-4">
+        <v-row>
+          <v-col cols="12" class="pb-0">
+            <div class="d-flex justify-space-between align-center flex-wrap">
+              <div class="summary-info">
+                <div><strong>Total de Parcelas:</strong> {{ installments.length }}</div>
+                <div><strong>Pendentes:</strong> {{ pendingInstallments.length }}</div>
+                <div><strong>Quitadas:</strong> {{ paidInstallments.length }}</div>
+              </div>
+              
+              <v-btn-toggle
+                v-model="selectedView"
+                mandatory
+                class="mt-2 mt-sm-0"
+                dense
+                outlined
+              >
+                <v-btn value="both" small>Ambos</v-btn>
+                <v-btn value="pending" small>Apenas Pendentes</v-btn>
+                <v-btn value="paid" small>Apenas Quitadas</v-btn>
+              </v-btn-toggle>
+            </div>
+          </v-col>
+        </v-row>
+        
+        <v-row class="mt-2">
+          <template v-if="selectedView === 'both'">
+            <v-col cols="12" md="6">
+              <div v-if="pendingInstallments.length > 0">
+                <stacked-bar-chart :installments="pendingInstallments" :graphTitle="pendingTitle"/>
+              </div>
+              <v-card v-else class="pa-6 d-flex justify-center align-center" height="450">
+                <div class="text-center">
+                  <v-icon large color="grey lighten-1">mdi-chart-bar</v-icon>
+                  <p class="text-subtitle-1 mt-2 grey--text">Não há parcelas pendentes para exibir</p>
+                </div>
+              </v-card>
+            </v-col>
+            <v-col cols="12" md="6">
+              <div v-if="paidInstallments.length > 0">
+                <stacked-bar-chart :installments="paidInstallments" :graphTitle="paidTitle"/>
+              </div>
+              <v-card v-else class="pa-6 d-flex justify-center align-center" height="450">
+                <div class="text-center">
+                  <v-icon large color="grey lighten-1">mdi-chart-bar</v-icon>
+                  <p class="text-subtitle-1 mt-2 grey--text">Não há parcelas quitadas para exibir</p>
+                </div>
+              </v-card>
+            </v-col>
+          </template>
+          
+          <template v-else-if="selectedView === 'pending'">
+            <v-col cols="12">
+              <div v-if="pendingInstallments.length > 0">
+                <stacked-bar-chart :installments="pendingInstallments" :graphTitle="pendingTitle"/>
+              </div>
+              <v-card v-else class="pa-6 d-flex justify-center align-center" height="450">
+                <div class="text-center">
+                  <v-icon large color="grey lighten-1">mdi-chart-bar</v-icon>
+                  <p class="text-subtitle-1 mt-2 grey--text">Não há parcelas pendentes para exibir</p>
+                </div>
+              </v-card>
+            </v-col>
+          </template>
+          
+          <template v-else-if="selectedView === 'paid'">
+            <v-col cols="12">
+              <div v-if="paidInstallments.length > 0">
+                <stacked-bar-chart :installments="paidInstallments" :graphTitle="paidTitle"/>
+              </div>
+              <v-card v-else class="pa-6 d-flex justify-center align-center" height="450">
+                <div class="text-center">
+                  <v-icon large color="grey lighten-1">mdi-chart-bar</v-icon>
+                  <p class="text-subtitle-1 mt-2 grey--text">Não há parcelas quitadas para exibir</p>
+                </div>
+              </v-card>
+            </v-col>
+          </template>
+        </v-row>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
 
-    components: {
-      StackedBarChart,
-    },
+<script>
+import { ref } from 'vue';
+import StackedBarChart from '@/components/shared/charts/BarChart.vue';
 
-    props: {
-      installments: {
-        type: Array,
-        required: true,
-      },
-    },
+export default {
+  name: 'ChartModal',
 
-    setup(props, { emit }) {
-  
-      const emitClose = () => {
-        emit('close', false)
-      };
-  
-      return {
-        emitClose,
-      };
+  components: {
+    StackedBarChart,
+  },
+
+  props: {
+    installments: {
+      type: Array,
+      required: true,
     },
-  };
-  </script>
-  
-  <style scoped>
-  .text-center {
-    text-align: center;
-    font-size: 16px;
-    color: gray;
+  },
+
+  setup(props, { emit }) {
+    const selectedView = ref('both');
+    
+    const pendingInstallments = props.installments.filter(installment => installment.status == 'Pendente');
+    const paidInstallments = props.installments.filter(installment => installment.status == 'Quitada');
+
+    const pendingTitle = "Distribuição de Parcelas Pendentes por Área";
+    const paidTitle = "Distribuição de Parcelas Quitadas por Área";
+
+    const emitClose = () => {
+      emit('close', false)
+    };
+
+    return {
+      pendingInstallments,
+      paidInstallments,
+      pendingTitle,
+      paidTitle,
+      emitClose,
+      selectedView,
+    };
+  },
+};
+</script>
+
+<style scoped>
+.text-center {
+  text-align: center;
+  font-size: 16px;
+  color: gray;
+}
+
+.summary-info {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  font-size: 14px;
+}
+
+@media (max-width: 599px) {
+  .summary-info {
+    flex-direction: column;
+    gap: 8px;
   }
-  </style>
-  
+}
+</style>

--- a/frontend/src/components/shared/charts/BarChart.vue
+++ b/frontend/src/components/shared/charts/BarChart.vue
@@ -1,6 +1,12 @@
 <template>
-  <div>
-    <bar-chart :data="chartData" :options="chartOptions" />
+  <div class="chart-container">
+    <h3 class="chart-title">{{ graphTitle }}</h3>
+    <div class="chart-wrapper">
+      <bar-chart :data="chartData" :options="chartOptions" />
+    </div>
+    <div v-if="chartData && chartData.datasets.length === 0" class="no-data">
+      <p>Não há dados para exibir.</p>
+    </div>
   </div>
 </template>
 
@@ -34,14 +40,21 @@ export default defineComponent({
       type: Array,
       required: true,
     },
+    graphTitle: {
+      type: String,
+      required: true,
+    },
   },
   data() {
     return {
       chartData: null,
       chartOptions: null,
       areaColors: {
-        'Engenharia de Software': '#4CAF50',
-        'Engenharia Eletrônica': '#2196F3',
+        'Engenharia de Software': '#4CAF50',   // Verde
+        'Engenharia de Energia': '#FFC107',    // Amarelo
+        'Engenharia Eletrônica': '#2196F3',    // Azul
+        'Engenharia Aeroespacial': '#9C27B0',  // Roxo
+        'Engenharia Automotiva': '#F44336',    // Vermelho
       }
     };
   },
@@ -50,13 +63,29 @@ export default defineComponent({
       handler() {
         this.prepareChartData();
       },
-      deep: true
+      deep: true,
+      immediate: true
     }
   },
-  created() {
+  mounted() {
     this.prepareChartData();
+    
+    // Adicionar responsividade ao redimensionar a janela
+    window.addEventListener('resize', this.handleResize);
+  },
+  beforeUnmount() {
+    // Remover o event listener quando o componente for desmontado
+    window.removeEventListener('resize', this.handleResize);
   },
   methods: {
+    handleResize() {
+      // Atualizar o gráfico quando a janela for redimensionada
+      if (this.chartData) {
+        this.$nextTick(() => {
+          ChartJS.defaults.font.size = window.innerWidth < 768 ? 10 : 12;
+        });
+      }
+    },
     formatCurrency(value) {
       return new Intl.NumberFormat('pt-BR', {
         style: 'currency',
@@ -65,20 +94,27 @@ export default defineComponent({
     },
     prepareChartData() {
       if (!this.installments || this.installments.length === 0) {
-        console.error("Nenhuma parcela foi encontrada.");
+        this.chartData = {
+          labels: [],
+          datasets: []
+        };
         return;
       }
 
-      const sortedInstallments = [...this.installments].sort((a, b) => 
-        new Date(a.estimated_date) - new Date(b.estimated_date)
-      );
+      const sortedInstallments = [...this.installments].sort((a, b) => {
+        const dateA = a.effective_date ? new Date(a.effective_date) : new Date(a.estimated_date);
+        const dateB = b.effective_date ? new Date(b.effective_date) : new Date(b.estimated_date);
+        return dateA - dateB;
+      });
 
       const labels = [];
       const areaNames = new Set();
       const areaDataMap = {};
+      let totalValue = 0;
 
       sortedInstallments.forEach((installment) => {
-        const monthYear = new Date(installment.estimated_date).toLocaleDateString("pt-BR", {
+        const dateToUse = installment.effective_date || installment.estimated_date;
+        const monthYear = new Date(dateToUse).toLocaleDateString("pt-BR", {
           month: "short",
           year: "numeric",
         });
@@ -87,20 +123,34 @@ export default defineComponent({
           labels.push(monthYear);
         }
 
-        Object.entries(installment.area_values).forEach(([area, value]) => {
-          areaNames.add(area);
-          if (!areaDataMap[area]) {
-            areaDataMap[area] = new Array(labels.length).fill(0);
+        Object.entries(installment.area_values || {}).forEach(([area, value]) => {
+          if (typeof value === 'number' && !isNaN(value)) {
+            areaNames.add(area);
+            if (!areaDataMap[area]) {
+              areaDataMap[area] = new Array(labels.length).fill(0);
+            }
+            const monthIndex = labels.indexOf(monthYear);
+            areaDataMap[area][monthIndex] = (areaDataMap[area][monthIndex] || 0) + value;
+            totalValue += value;
           }
-          const monthIndex = labels.indexOf(monthYear);
-          areaDataMap[area][monthIndex] = (areaDataMap[area][monthIndex] || 0) + value;
         });
       });
 
-      const datasets = Array.from(areaNames).map((area) => ({
+      const defaultColor = '#777777';
+      
+      const areaTotals = {};
+      Array.from(areaNames).forEach(area => {
+        areaTotals[area] = (areaDataMap[area] || []).reduce((sum, val) => sum + val, 0);
+      });
+      
+      const sortedAreas = Array.from(areaNames).sort((a, b) => areaTotals[b] - areaTotals[a]);
+      
+      const datasets = sortedAreas.map((area) => ({
         label: area,
         data: areaDataMap[area],
-        backgroundColor: this.areaColors[area] || this.getRandomColor(),
+        backgroundColor: this.areaColors[area] || defaultColor,
+        borderColor: '#ffffff',
+        borderWidth: 1,
       }));
 
       this.chartData = {
@@ -114,23 +164,40 @@ export default defineComponent({
         plugins: {
           legend: {
             position: "top",
+            labels: {
+              usePointStyle: true,
+              padding: 15,
+              font: {
+                size: 12
+              }
+            }
           },
           title: {
-            display: true,
-            text: "Distribuição de Parcelas por Áreas",
-            font: {
-              size: 16,
-              weight: 'bold'
-            }
+            display: false,
           },
           tooltip: {
             mode: 'index',
             intersect: false,
+            backgroundColor: 'rgba(0, 0, 0, 0.8)',
+            padding: 10,
+            titleFont: {
+              size: 14,
+              weight: 'bold'
+            },
+            bodyFont: {
+              size: 13
+            },
             callbacks: {
               label: (context) => {
                 const label = context.dataset.label || '';
                 const value = context.parsed.y;
-                return `${label}: ${this.formatCurrency(value)}`;
+                const percentage = totalValue > 0 
+                  ? ((value / totalValue) * 100).toFixed(1) + '%' 
+                  : '0%';
+                return `${label}: ${this.formatCurrency(value)} (${percentage})`;
+              },
+              title: (tooltipItems) => {
+                return `Mês: ${tooltipItems[0].label}`;
               }
             }
           }
@@ -142,8 +209,17 @@ export default defineComponent({
               display: true,
               text: 'Mês',
               font: {
-                weight: 'bold'
-              }
+                weight: 'bold',
+                size: 14
+              },
+              padding: 10
+            },
+            grid: {
+              display: false
+            },
+            ticks: {
+              maxRotation: 45,
+              minRotation: 45
             }
           },
           y: {
@@ -153,30 +229,71 @@ export default defineComponent({
               display: true,
               text: 'Valor (R$)',
               font: {
-                weight: 'bold'
-              }
+                weight: 'bold',
+                size: 14
+              },
+              padding: 10
             },
             ticks: {
               callback: (value) => this.formatCurrency(value)
             }
           }
         },
+        animation: {
+          duration: 1000,
+          easing: 'easeOutQuart'
+        }
       };
-    },
-    getRandomColor() {
-      const letters = "0123456789ABCDEF";
-      let color = "#";
-      for (let i = 0; i < 6; i++) {
-        color += letters[Math.floor(Math.random() * 16)];
-      }
-      return color;
     },
   },
 });
 </script>
 
 <style scoped>
-div {
-  height: 400px;
+.chart-container {
+  display: flex;
+  flex-direction: column;
+  height: 450px;
+  padding: 15px;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.chart-title {
+  text-align: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: #333333;
+  margin-bottom: 15px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+.chart-wrapper {
+  flex: 1;
+  position: relative;
+}
+
+.no-data {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #888888;
+  font-style: italic;
+}
+
+@media (max-width: 767px) {
+  .chart-container {
+    height: 350px;
+    padding: 10px;
+  }
+  
+  .chart-title {
+    font-size: 16px;
+    margin-bottom: 10px;
+  }
 }
 </style>


### PR DESCRIPTION
## Description

Two new graphs have been added to the modal:

- Pending Installments Graph: Displays a visual representation of pending installments.

- Paid Installments Graph: Provides a clear overview of paid installments.

UI Improvements:

- The modal's user interface has been enhanced to offer a more intuitive and informative experience.

- Users can now view a brief summary of installments directly within the modal, providing key insights at a glance.

Added functionality to toggle between graphs: Users can choose to view:

- Pending installments graph.

- Paid installments graph.

- Both graphs together for a comprehensive comparison.


## Change Type

- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [x] Minor changes in old functionality
