### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/domain/projects/details/installment/ProjectInstallmentChart.vue
+++ b/frontend/src/components/domain/projects/details/installment/ProjectInstallmentChart.vue
@@ -3,7 +3,7 @@
     <v-card class="rounded-lg">
       <v-card-title class="d-flex justify-space-between align-center pa-4">
         <h2 class="text-h5 text-md-h4">Visualização de Parcelas por Área</h2>
-        <v-btn icon @click="emitClose" class="ml-2">
+        <v-btn icon aria-label="Fechar" @click="emitClose" class="ml-2">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-card-title>

--- a/frontend/src/components/domain/projects/form/AreasSection.vue
+++ b/frontend/src/components/domain/projects/form/AreasSection.vue
@@ -11,7 +11,7 @@
           :rules="[rules.required, rules.percentage]" required></v-text-field>
       </v-col>
       <v-col cols="2" class="text-center">
-        <v-btn icon color="red" @click="$emit('remove-area', index)">
+        <v-btn icon aria-label="Remover Área" color="red" @click="$emit('remove-area', index)">
           <v-icon>mdi-delete</v-icon>
         </v-btn>
       </v-col>

--- a/frontend/src/components/domain/projects/form/ProjectForm.vue
+++ b/frontend/src/components/domain/projects/form/ProjectForm.vue
@@ -109,7 +109,7 @@
                 :rules="[rules.required, rules.percentage]" required></v-text-field>
             </v-col>
             <v-col cols="2" class="text-center">
-              <v-btn icon color="red" @click="removeArea(index)">
+              <v-btn icon aria-label="Remover Área" color="red" @click="removeArea(index)">
                 <v-icon>mdi-delete</v-icon>
               </v-btn>
             </v-col>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only `v-btn` components.
🎯 Why: To improve accessibility for screen readers by providing context to icon-only buttons (Close button and Remove Area buttons).
📸 Before/After: Visuals remain unchanged, but the DOM now includes meaningful labels.
♿ Accessibility: Ensures screen readers can announce the purpose of the buttons.

---
*PR created automatically by Jules for task [9610224997880412192](https://jules.google.com/task/9610224997880412192) started by @berssutti*